### PR TITLE
Added Worksheet::ColumnNotFoundError 

### DIFF
--- a/lib/sheets_db/worksheet.rb
+++ b/lib/sheets_db/worksheet.rb
@@ -3,7 +3,7 @@ require_relative "worksheet/row"
 
 module SheetsDB
   class Worksheet
-    class WorksheetColumnNotFoundError < StandardError; end
+    class ColumnNotFoundError < StandardError; end
 
     include Enumerable
 
@@ -46,7 +46,7 @@ module SheetsDB
     def get_definition_and_column(attribute_name)
       attribute_definition = attribute_definitions.fetch(attribute_name, {})
       column_name = attribute_definition.fetch(:column_name, attribute_name.to_s)
-      raise WorksheetColumnNotFoundError, column_name if columns[column_name].nil?
+      raise ColumnNotFoundError, column_name if columns[column_name].nil?
       [
         attribute_definition,
         columns[column_name]

--- a/lib/sheets_db/worksheet.rb
+++ b/lib/sheets_db/worksheet.rb
@@ -3,6 +3,8 @@ require_relative "worksheet/row"
 
 module SheetsDB
   class Worksheet
+    class WorksheetColumnNotFoundError < StandardError; end
+
     include Enumerable
 
     attr_reader :spreadsheet, :google_drive_resource, :type
@@ -43,9 +45,11 @@ module SheetsDB
 
     def get_definition_and_column(attribute_name)
       attribute_definition = attribute_definitions.fetch(attribute_name, {})
+      column_name = attribute_definition.fetch(:column_name, attribute_name.to_s)
+      raise WorksheetColumnNotFoundError, column_name if columns[column_name].nil?
       [
         attribute_definition,
-        columns[attribute_definition.fetch(:column_name, attribute_name.to_s)]
+        columns[column_name]
       ]
     end
 

--- a/spec/sheets_db/worksheet_spec.rb
+++ b/spec/sheets_db/worksheet_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe SheetsDB::Worksheet do
       allow(subject).to receive(:convert_value).with("April 15", { type: DateTime }).and_return("4/15")
       expect(subject.attribute_at_row_position(:first_name, 2)).to eq("4/15")
     end
+
+    it "raises a WorksheetColumnNotFoundError if accessing a column that does not exist" do
+      allow(row_class).to receive(:attribute_definitions).and_return({ first_name: { column_name: "Wrong Column" } })
+      expect {
+        subject.attribute_at_row_position(:first_name, 2)
+      }.to raise_error(described_class::WorksheetColumnNotFoundError)
+    end
   end
 
   describe "#update_attributes_at_row_position" do
@@ -71,6 +78,13 @@ RSpec.describe SheetsDB::Worksheet do
       expect(raw_worksheet).to receive(:[]=).with(2, 6, "tasties")
       expect(raw_worksheet).to receive(:synchronize)
       subject.update_attributes_at_row_position({ first_name: "Bonnie", last_name: "McFragile", colors: ["green", "white"], the_food: "tasties" }, row_position: 2)
+    end
+
+    it "raises a WorksheetColumnNotFoundError if accessing a column that does not exist" do
+      allow(row_class).to receive(:attribute_definitions).and_return({ first_name: { column_name: "Wrong Column" } })
+      expect {
+        subject.update_attributes_at_row_position({ first_name: "Bonnie" }, row_position: 2)
+      }.to raise_error(described_class::WorksheetColumnNotFoundError)
     end
   end
 

--- a/spec/sheets_db/worksheet_spec.rb
+++ b/spec/sheets_db/worksheet_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe SheetsDB::Worksheet do
       expect(subject.attribute_at_row_position(:first_name, 2)).to eq("4/15")
     end
 
-    it "raises a WorksheetColumnNotFoundError if accessing a column that does not exist" do
+    it "raises a ColumnNotFoundError if accessing a column that does not exist" do
       allow(row_class).to receive(:attribute_definitions).and_return({ first_name: { column_name: "Wrong Column" } })
       expect {
         subject.attribute_at_row_position(:first_name, 2)
-      }.to raise_error(described_class::WorksheetColumnNotFoundError)
+      }.to raise_error(described_class::ColumnNotFoundError)
     end
   end
 
@@ -80,11 +80,11 @@ RSpec.describe SheetsDB::Worksheet do
       subject.update_attributes_at_row_position({ first_name: "Bonnie", last_name: "McFragile", colors: ["green", "white"], the_food: "tasties" }, row_position: 2)
     end
 
-    it "raises a WorksheetColumnNotFoundError if accessing a column that does not exist" do
+    it "raises a ColumnNotFoundError if accessing a column that does not exist" do
       allow(row_class).to receive(:attribute_definitions).and_return({ first_name: { column_name: "Wrong Column" } })
       expect {
         subject.update_attributes_at_row_position({ first_name: "Bonnie" }, row_position: 2)
-      }.to raise_error(described_class::WorksheetColumnNotFoundError)
+      }.to raise_error(described_class::ColumnNotFoundError)
     end
   end
 


### PR DESCRIPTION
When defining attributes with a column_name, if you mistype a column_name or the column doesn't exist in the worksheet, an error will be thrown.

```
class Rowboat < SheetsDB::Worksheet::Row
  attribute :foo, column_name: "BAD COLUMN NAME"
end
```