### PR TITLE
Added WorksheetNotFoundError

### DIFF
--- a/spec/sheets_db/spreadsheet_spec.rb
+++ b/spec/sheets_db/spreadsheet_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SheetsDB::Spreadsheet do
       test_class.has_many :widgets, worksheet_name: "Widgets", class_name: :collection_class
       expect {
         subject.widgets
-      }.to raise_error(described_class::WorksheetNotFoundError)
+      }.to raise_error(described_class::WorksheetNotFoundError, "Widgets")
     end
   end
 

--- a/spec/sheets_db/spreadsheet_spec.rb
+++ b/spec/sheets_db/spreadsheet_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe SheetsDB::Spreadsheet do
         test_class.has_many :widgets, worksheet_name: "Widgets2", class_name: :collection_class
       }.to raise_error(described_class::WorksheetAssociationAlreadyRegisteredError)
     end
+
+    it "raises an error if the worksheet is not found" do
+      allow(GoogleDriveSessionProxy::DUMMY_FILES[:spreadsheet]).
+        to receive(:worksheet_by_title).
+        with("Widgets").
+        and_return(nil)
+      test_class.has_many :widgets, worksheet_name: "Widgets", class_name: :collection_class
+      expect {
+        subject.widgets
+      }.to raise_error(described_class::WorksheetNotFoundError)
+    end
   end
 
   describe "#find_association_by_id" do


### PR DESCRIPTION
When defining spreadsheet associations, a runtime error is now thrown if you add an association that references a worksheet that does not exist.

```
class SheetStreet < SheetsDB::Spreadsheet
  has_many :foos, worksheet_name: "NotFoundSheet", class_name: "Bar"
end
```