### PR TITLE
Add float column type

### DIFF
--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -169,7 +169,7 @@ end
 
 The only required argument to the `attribute` class method is the name of the column itself.  All other options are optional:
 
-`type`: The `attribute` method currently supports four types: `Integer`, `DateTime`, `Boolean` and the default `String`.  Any other value given to the `type` option will be ignored and the default will be used.  (Note that the `Boolean` type must be specified as a string or symbol (`type: :Boolean`) since there is no actual `Boolean` class in Ruby.)
+`type`: The `attribute` method currently supports five types: `Integer`, `Float`, `DateTime`, `Boolean` and the default `String`.  Any other value given to the `type` option will be ignored and the default will be used.  (Note that the `Boolean` type must be specified as a string or symbol (`type: :Boolean`) since there is no actual `Boolean` class in Ruby.)
 
 `multiple`: This option defaults to false.  If true, it tells SheetsDB to parse the value as a comma-separated list of values, and return an array by splitting on the comma (if no comma is found, it will return a single element array).
 

--- a/lib/sheets_db/worksheet.rb
+++ b/lib/sheets_db/worksheet.rb
@@ -167,6 +167,8 @@ module SheetsDB
       converted_value = case attribute_definition[:type].to_s
       when "Integer"
         raw_value.to_i
+      when "Float"
+        raw_value.to_f
       when "DateTime"
         DateTime.strptime(raw_value, "%m/%d/%Y %H:%M:%S")
       when "Boolean"

--- a/spec/sheets_db/worksheet_spec.rb
+++ b/spec/sheets_db/worksheet_spec.rb
@@ -235,6 +235,10 @@ RSpec.describe SheetsDB::Worksheet do
       expect(subject.convert_value("14", { type: Integer })).to eq(14)
     end
 
+    it "returns float value if type is Float" do
+      expect(subject.convert_value("1.54", { type: Float })).to eq(1.54)
+    end
+
     it "returns DateTime value if type is DateTime" do
       expect(subject.convert_value("4/15/2016 10:15:30", { type: DateTime })).to eq(
         DateTime.parse("2016-04-15 10:15:30")


### PR DESCRIPTION
This adds `Float` as a valid column type for Worksheets.