### PR TITLE
Fix attribute inheritance bug

### DIFF
--- a/lib/sheets_db/worksheet/row.rb
+++ b/lib/sheets_db/worksheet/row.rb
@@ -7,7 +7,10 @@ module SheetsDB
       class << self
         def inherited(subclass)
           super
-          subclass.instance_variable_set(:@attribute_definitions, @attribute_definitions)
+          subclass.instance_variable_set(
+            :@attribute_definitions,
+            Marshal.load(Marshal.dump(@attribute_definitions))
+          )
         end
 
         def attribute(name, type: String, multiple: false, transform: nil, column_name: nil, if_column_missing: nil)

--- a/spec/sheets_db/worksheet/row_spec.rb
+++ b/spec/sheets_db/worksheet/row_spec.rb
@@ -8,6 +8,25 @@ RSpec.describe SheetsDB::Worksheet::Row do
     row_class.instance_variable_set(:@attribute_definitions, nil)
   end
 
+  describe ".attribute_definitions" do
+    before(:each) do
+      row_class.attribute :foo
+    end
+
+    it "inherits from base class" do
+      subclass = Class.new(row_class)
+      expect(subclass.attribute_definitions.keys).to include(:foo)
+    end
+
+    it "is not shared between subclasses" do
+      subclass1 = Class.new(row_class)
+      subclass2 = Class.new(row_class)
+      subclass1.attribute :smarf
+      expect(subclass1.attribute_definitions.keys).to eq([:foo, :smarf])
+      expect(subclass2.attribute_definitions.keys).to eq([:foo])
+    end
+  end
+
   describe ".attribute" do
     context "dynamic methods" do
       before(:each) do


### PR DESCRIPTION
This fixes a bug in which subclasses inheriting from a row class were sharing attribute definitions - the hash was not being duped, so the reference was to the same object.  The dup uses `Marshal.load` and `Marshal.dump` for a deep duplicate, since attribute definitions is a hash of hashes.