### PR TITLE
Add convenience methods: ID extract from URL, direct read/write

### DIFF
--- a/lib/sheets_db/spreadsheet.rb
+++ b/lib/sheets_db/spreadsheet.rb
@@ -5,6 +5,7 @@ module SheetsDB
     class LastWorksheetCannotBeDeletedError < StandardError; end
 
     SHEET_URL_REGEX = /spreadsheets\/d\/(?<sheet_id>[^\/]+)\//.freeze
+    DEFAULT_WORKSHEET_TITLE = "Sheet1".freeze
 
     set_resource_type GoogleDrive::Spreadsheet
 
@@ -34,6 +35,15 @@ module SheetsDB
       def extract_id_from_string(id_string)
         (matches = SHEET_URL_REGEX.match(id_string)) ? matches[:sheet_id] : id_string.gsub("/", "")
       end
+    end
+
+    def write_raw_data_to_worksheet!(data, worksheet_title: nil, rewrite: false)
+      find_or_create_worksheet!(title: worksheet_title || DEFAULT_WORKSHEET_TITLE).
+        write_raw_data!(data, rewrite: rewrite)
+    end
+
+    def existing_raw_data_from_worksheet(worksheet_title: nil)
+      find_worksheet!(title: worksheet_title || DEFAULT_WORKSHEET_TITLE).existing_raw_data
     end
 
     def find_association_by_id(association_name, id)
@@ -99,7 +109,7 @@ module SheetsDB
     end
 
     def clean_up_default_worksheet!(force: false)
-      default_sheet = google_drive_resource.worksheet_by_title("Sheet1")
+      default_sheet = google_drive_resource.worksheet_by_title(DEFAULT_WORKSHEET_TITLE)
       return unless default_sheet
 
       raise LastWorksheetCannotBeDeletedError if google_drive_resource.worksheets.count == 1

--- a/lib/sheets_db/spreadsheet.rb
+++ b/lib/sheets_db/spreadsheet.rb
@@ -4,6 +4,8 @@ module SheetsDB
     class WorksheetNotFoundError < Resource::ChildResourceNotFoundError; end
     class LastWorksheetCannotBeDeletedError < StandardError; end
 
+    SHEET_URL_REGEX = /spreadsheets\/d\/(?<sheet_id>[^\/]+)\//.freeze
+
     set_resource_type GoogleDrive::Spreadsheet
 
     class << self
@@ -27,6 +29,10 @@ module SheetsDB
         define_method(resource) do
           worksheet_association(resource, **kwargs)
         end
+      end
+
+      def extract_id_from_string(id_string)
+        (matches = SHEET_URL_REGEX.match(id_string)) ? matches[:sheet_id] : id_string.gsub("/", "")
       end
     end
 

--- a/lib/sheets_db/spreadsheet.rb
+++ b/lib/sheets_db/spreadsheet.rb
@@ -4,7 +4,7 @@ module SheetsDB
     class WorksheetNotFoundError < Resource::ChildResourceNotFoundError; end
     class LastWorksheetCannotBeDeletedError < StandardError; end
 
-    SHEET_URL_REGEX = /spreadsheets\/d\/(?<sheet_id>[^\/]+)\//.freeze
+    SHEET_URL_REGEX = /spreadsheets\/d\/(?<sheet_id>[^\/]+)/.freeze
     DEFAULT_WORKSHEET_TITLE = "Sheet1".freeze
 
     set_resource_type GoogleDrive::Spreadsheet

--- a/spec/sheets_db/spreadsheet_spec.rb
+++ b/spec/sheets_db/spreadsheet_spec.rb
@@ -30,22 +30,15 @@ RSpec.describe SheetsDB::Spreadsheet do
   end
 
   describe ".extract_id_from_string" do
-    it "returns the id from a Google Drive URL" do
-      expect(
-        test_class.extract_id_from_string(
-          "https://docs.google.com/spreadsheets/d/1a2b3c4d5e6f7g8h9i0j/edit#gid=0"
-        )
-      ).to eq("1a2b3c4d5e6f7g8h9i0j")
-    end
-
-    it "returns the id if not a Google Drive URL" do
-      expect(test_class.extract_id_from_string("1a2b3c4d5e6f7g8h9i0j")).
-        to eq("1a2b3c4d5e6f7g8h9i0j")
-    end
-
-    it "removes all slashes around the ID" do
-      expect(test_class.extract_id_from_string("/1a2b3c4d5e6f7g8h9i0j/")).
-        to eq("1a2b3c4d5e6f7g8h9i0j")
+    {
+      "a full URL" => "https://docs.google.com/spreadsheets/d/1a2b3c4d5e6f7g8h9i0j/edit#gid=0",
+      "a URL without end slash" => "https://docs.google.com/spreadsheets/d/1a2b3c4d5e6f7g8h9i0j",
+      "a string that's just the ID" => "1a2b3c4d5e6f7g8h9i0j",
+      "a string with slashes around the ID" => "/1a2b3c4d5e6f7g8h9i0j/"
+    }.each do |description, string|
+      it "returns the ID from #{description}" do
+        expect(test_class.extract_id_from_string(string)).to eq("1a2b3c4d5e6f7g8h9i0j")
+      end
     end
   end
 

--- a/spec/sheets_db/spreadsheet_spec.rb
+++ b/spec/sheets_db/spreadsheet_spec.rb
@@ -25,6 +25,26 @@ RSpec.describe SheetsDB::Spreadsheet do
     end
   end
 
+  describe ".extract_id_from_string" do
+    it "returns the id from a Google Drive URL" do
+      expect(
+        test_class.extract_id_from_string(
+          "https://docs.google.com/spreadsheets/d/1a2b3c4d5e6f7g8h9i0j/edit#gid=0"
+        )
+      ).to eq("1a2b3c4d5e6f7g8h9i0j")
+    end
+
+    it "returns the id if not a Google Drive URL" do
+      expect(test_class.extract_id_from_string("1a2b3c4d5e6f7g8h9i0j")).
+        to eq("1a2b3c4d5e6f7g8h9i0j")
+    end
+
+    it "removes all slashes around the ID" do
+      expect(test_class.extract_id_from_string("/1a2b3c4d5e6f7g8h9i0j/")).
+        to eq("1a2b3c4d5e6f7g8h9i0j")
+    end
+  end
+
   describe "#find_association_by_id" do
     it "singular proxy for find_associations_by_ids" do
       allow(subject).to receive(:find_associations_by_ids).


### PR DESCRIPTION
- **Add ID extraction from URL**
- **Add direct read/write via spreadsheet**

## Description
Adds a few convenience methods - extracting an ID from a spreadsheet URL string, and directly reading and writing to/from a worksheet (defaulting to "Sheet1") from an instance of SheetsDB::Spreadsheet, which is a very common ad-hoc use.