### PR TITLE
Fix ID extraction to handle nil, add human_url delegation

### DIFF
--- a/lib/sheets_db/resource.rb
+++ b/lib/sheets_db/resource.rb
@@ -72,7 +72,7 @@ module SheetsDB
     end
 
     extend Forwardable
-    def_delegators :google_drive_resource, :id, :name
+    def_delegators :google_drive_resource, :id, :name, :human_url
     def_delegator :google_drive_resource, :created_time, :created_at
     def_delegator :google_drive_resource, :modified_time, :updated_at
 

--- a/lib/sheets_db/session.rb
+++ b/lib/sheets_db/session.rb
@@ -5,6 +5,7 @@ module SheetsDB
     class IllegalDefaultError < StandardError; end
     class NoDefaultSetError < StandardError; end
     class InvalidGoogleDriveUrlError < ArgumentError; end
+    class GoogleDriveIdNotFoundError < ArgumentError; end
 
     def self.default=(default)
       unless default.is_a?(self)
@@ -30,6 +31,9 @@ module SheetsDB
 
     def raw_file_by_id(id)
       @google_drive_session.file_by_id(id)
+    rescue Google::Apis::ClientError => e
+      (raise GoogleDriveIdNotFoundError, id) if e.message.match(/File not found/)
+      raise
     end
 
     def raw_file_by_url(url)

--- a/lib/sheets_db/spreadsheet.rb
+++ b/lib/sheets_db/spreadsheet.rb
@@ -33,7 +33,7 @@ module SheetsDB
       end
 
       def extract_id_from_string(id_string)
-        (matches = SHEET_URL_REGEX.match(id_string)) ? matches[:sheet_id] : id_string.gsub("/", "")
+        (matches = SHEET_URL_REGEX.match(id_string)) ? matches[:sheet_id] : id_string&.gsub("/", "")
       end
     end
 

--- a/spec/sheets_db/resource_spec.rb
+++ b/spec/sheets_db/resource_spec.rb
@@ -148,6 +148,13 @@ RSpec.describe SheetsDB::Resource do
     end
   end
 
+  describe "#human_url" do
+    it "delegates to raw resource" do
+      allow(raw_file).to receive(:human_url).and_return(:foo)
+      expect(subject.human_url).to eq(:foo)
+    end
+  end
+
   describe "#created_at" do
     it "delegates to raw resource #created_time" do
       allow(raw_file).to receive(:created_time).and_return(:foo)

--- a/spec/sheets_db/session_spec.rb
+++ b/spec/sheets_db/session_spec.rb
@@ -51,6 +51,23 @@ RSpec.describe SheetsDB::Session do
       allow(wrapped_session).to receive(:file_by_id).with(:the_id).and_return(:raw_file)
       expect(subject.raw_file_by_id(:the_id)).to eq :raw_file
     end
+
+    it "raises GoogleDriveIdNotFoundError if ID is not found" do
+      allow(wrapped_session).to receive(:file_by_id).
+        with(:the_id).
+        and_raise(Google::Apis::ClientError, "File not found: the_id")
+      expect {
+        subject.raw_file_by_id(:the_id)
+      }.to raise_error(described_class::GoogleDriveIdNotFoundError, "the_id")
+    end
+
+    it "bubbles error through if not a file not found error" do
+      error = GoogleDrive::Error.new("something totally different")
+      allow(wrapped_session).to receive(:file_by_id).with(:the_id).and_raise(error)
+      expect {
+        subject.raw_file_by_id(:the_id)
+      }.to raise_error(error)
+    end
   end
 
   describe "#raw_file_by_url" do

--- a/spec/sheets_db/spreadsheet_spec.rb
+++ b/spec/sheets_db/spreadsheet_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe SheetsDB::Spreadsheet do
         expect(test_class.extract_id_from_string(string)).to eq("1a2b3c4d5e6f7g8h9i0j")
       end
     end
+
+    it "returns nil if given nil" do
+      expect(test_class.extract_id_from_string(nil)).to be_nil
+    end
   end
 
   describe "#write_raw_data_to_worksheet!" do


### PR DESCRIPTION
## Description
More convenience method updates - delegates "human_url" to the google drive resource, fixes ID extraction to properly handle "nil", and wraps the Google API client "file not found" error (since it's another one of the Google API errors where the error type itself isn't distinct enough).